### PR TITLE
Drop SLACK_WEBHOOK_URL secret from workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -9,9 +9,6 @@ on:
       language:
         required: true
         type: string
-    secrets:
-      SLACK_WEBHOOK_URL:
-        required: true
 
 jobs:
   codeql-analysis:

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -15,9 +15,6 @@ on:
       conda-env-name:
         required: true
         type: string
-    secrets:
-      SLACK_WEBHOOK_URL:
-        required: true
 
 jobs:
   pytest-with-coverage:

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -15,9 +15,6 @@ on:
       conda-env-name:
         required: true
         type: string
-    secrets:
-      SLACK_WEBHOOK_URL:
-        required: true
 
 jobs:
   sphinx-linkcheck:


### PR DESCRIPTION
No longer needed.
This should have been done in PR#1.