### PR TITLE
Add reusable workflow for automatic milestone assignment to new issues and PRs

### DIFF
--- a/.github/workflows/auto-milestone-issue-pr.yaml
+++ b/.github/workflows/auto-milestone-issue-pr.yaml
@@ -1,0 +1,24 @@
+# Reusable workflow to automatically add current milestone to issues and PRs
+
+name: auto-milestone-issue-pr
+
+on:
+  workflow_call:
+
+jobs:
+  add_milestone:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: benelan/milestone-action@v3
+        with:
+          # If true, add the milestone with the farthest due date. By default,
+          # the action adds the current milestone (the closest due date).
+          farthest: false
+
+          # If true, overwrite existing milestones on issues and pull requests.
+          # By default, the action exits if a milestone has already been added.
+          overwrite: false
+
+          # If true, add the only open milestone in a repo, even if there is no
+          # due date. By default, milestones with no due date are ignored.
+          single: false

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Reusable GitHub Actions workflows for MOAD repositories and workflow management 
 
 ## Changes
 
+### 2-Feb-2024
+
+Added `auto-milestone-issue-pr.yaml` workflow to automatically add current milestone to new issues
+and PRs.
+
+
 ### 22-Mar-2024
 
 Added Codecov token to `pytest-with-coverage` workflow to re-enable coverage
@@ -47,6 +53,7 @@ YAML blobs to use the reusable workflows in other repositories.
 
 ```yaml
 name: Assign Issue/PR
+
 on:
   issues:
     types:
@@ -56,12 +63,37 @@ on:
     types:
       - reopened
       - opened
+
 jobs:
   auto_assign:
     permissions:
       issues: write
       pull-requests: write
     uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main
+```
+
+
+### `auto-milestone-issue-pr`
+
+```yaml
+name: Add Milestone to Issue/PR
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  add_milestone:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main
 ```
 
 


### PR DESCRIPTION
Introduce a workflow that automatically assigns the current milestone to newly opened issues and pull requests, streamlining milestone management.