### PR TITLE
Update auto-milestone action to use commit hash

### DIFF
--- a/.github/workflows/auto-milestone-issue-pr.yaml
+++ b/.github/workflows/auto-milestone-issue-pr.yaml
@@ -9,7 +9,7 @@ jobs:
   add_milestone:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: benelan/milestone-action@v3
+      - uses: benelan/milestone-action@ae503769af66e741a9d7f76052058e1c3054fd7e
         with:
           # If true, add the milestone with the farthest due date. By default,
           # the action adds the current milestone (the closest due date).


### PR DESCRIPTION
Use commit hash of latest release of benelan/milestone-action
instead of v3 because commit hashes are best practice for
security on 3rd party action workflows.