### PR TITLE
Improve workflows based on zizmor static analysis

### DIFF
--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -2,6 +2,9 @@
 # repo to Doug
 
 name: Assign Issue/PR
+
+permissions: {}
+
 on:
   issues:
     types:
@@ -11,6 +14,7 @@ on:
     types:
       - reopened
       - opened
+
 jobs:
   auto_assign:
     permissions:

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -20,4 +20,4 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -18,6 +18,6 @@ on:
 jobs:
   auto_assign:
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write  # Required to add assignees to issues
+      pull-requests: write  # Required to add assignees to pull requests
     uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -11,7 +11,7 @@ jobs:
   assign:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@v9  # zizmor: ignore[unpinned-uses]
         with:
           script: |
             github.rest.issues.addAssignees({

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   assign:
+    name: Auto-assign to Doug
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/github-script@v9  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -2,6 +2,8 @@
 
 name: auto-assign
 
+permissions: {}
+
 on:
   workflow_call:
 

--- a/.github/workflows/auto-milestone-issue-pr.yaml
+++ b/.github/workflows/auto-milestone-issue-pr.yaml
@@ -2,6 +2,8 @@
 
 name: auto-milestone-issue-pr
 
+permissions: {}
+
 on:
   workflow_call:
 

--- a/.github/workflows/auto-milestone-issue-pr.yaml
+++ b/.github/workflows/auto-milestone-issue-pr.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   add_milestone:
+    name: Add current milestone to issue/PR
     runs-on: 'ubuntu-latest'
     steps:
       - uses: benelan/milestone-action@ae503769af66e741a9d7f76052058e1c3054fd7e

--- a/.github/workflows/codeql-analysis-this-repo.yaml
+++ b/.github/workflows/codeql-analysis-this-repo.yaml
@@ -19,6 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'python' ]
-    uses: UBC-MOAD/gha-workflows/.github/workflows/codeql-analysis.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/codeql-analysis.yaml@main  # zizmor: ignore[unpinned-uses]
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/codeql-analysis-this-repo.yaml
+++ b/.github/workflows/codeql-analysis-this-repo.yaml
@@ -1,5 +1,7 @@
 name: "CodeQL"
 
+permissions: {}
+
 on:
   push:
     branches: [ '*' ]

--- a/.github/workflows/codeql-analysis-this-repo.yaml
+++ b/.github/workflows/codeql-analysis-this-repo.yaml
@@ -12,9 +12,9 @@ jobs:
   analyze:
     name: Analyze
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read  # Required to checkout code and run CodeQL analysis
+      contents: read  # Required to checkout code and run CodeQL analysis
+      security-events: write  # Required to upload CodeQL analysis results
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false  # Required to avoid exposing secrets to CodeQL analysis of forked PRs
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -3,6 +3,8 @@
 
 name: codeql-analysis
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -17,12 +17,12 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4  # zizmor: ignore[unpinned-uses]
         with:
           languages: ${{ inputs.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   codeql-analysis:
+    name: CodeQL analysis for ${{ inputs.language }}
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository

--- a/.github/workflows/pixi-lockfile-updater.yaml
+++ b/.github/workflows/pixi-lockfile-updater.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   pixi-update:
+    name: Update pixi lockfile and create pull request
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/pixi-lockfile-updater.yaml
+++ b/.github/workflows/pixi-lockfile-updater.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false  # Required to avoid exposing secrets to the lockfile update process in forked PRs
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11

--- a/.github/workflows/pixi-lockfile-updater.yaml
+++ b/.github/workflows/pixi-lockfile-updater.yaml
@@ -2,6 +2,8 @@
 
 name: pixi-lockfile-updater
 
+permissions: {}
+
 on:
   workflow_call:
     # No inputs or secrets needed for this workflow, but we still need to specify

--- a/.github/workflows/pixi-lockfile-updater.yaml
+++ b/.github/workflows/pixi-lockfile-updater.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11

--- a/.github/workflows/pixi-pytest-with-coverage.yaml
+++ b/.github/workflows/pixi-pytest-with-coverage.yaml
@@ -32,7 +32,9 @@ jobs:
           environments: ${{ inputs.environment }}
 
       - name: Run pytest-with-coverage
-        run: pixi run -e ${{ inputs.environment }} pytest --cov=$GITHUB_WORKSPACE --cov-report=xml
+        run: pixi run -e ${INPUTS_ENVIRONMENT} pytest --cov=$GITHUB_WORKSPACE --cov-report=xml
+        env:
+          INPUTS_ENVIRONMENT: ${{ inputs.environment }}
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f

--- a/.github/workflows/pixi-pytest-with-coverage.yaml
+++ b/.github/workflows/pixi-pytest-with-coverage.yaml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   pytest-with-coverage:
+    name: pytest with coverage in ${{ inputs.environment }} environment
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository

--- a/.github/workflows/pixi-pytest-with-coverage.yaml
+++ b/.github/workflows/pixi-pytest-with-coverage.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false  # Required to avoid exposing secrets to pytest run in forked PRs
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11

--- a/.github/workflows/pixi-pytest-with-coverage.yaml
+++ b/.github/workflows/pixi-pytest-with-coverage.yaml
@@ -3,6 +3,8 @@
 
 name: pixi-pytest-with-coverage
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pixi-pytest-with-coverage.yaml
+++ b/.github/workflows/pixi-pytest-with-coverage.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11

--- a/.github/workflows/pixi-sphinx-linkcheck.yaml
+++ b/.github/workflows/pixi-sphinx-linkcheck.yaml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   sphinx-linkcheck:
+    name: Sphinx linkcheck via Pixi
     runs-on: 'ubuntu-latest'
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/pixi-sphinx-linkcheck.yaml
+++ b/.github/workflows/pixi-sphinx-linkcheck.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11

--- a/.github/workflows/pixi-sphinx-linkcheck.yaml
+++ b/.github/workflows/pixi-sphinx-linkcheck.yaml
@@ -2,6 +2,8 @@
 
 name: pixi-sphinx-linkcheck
 
+permissions: {}
+
 on:
   workflow_call:
 

--- a/.github/workflows/pixi-sphinx-linkcheck.yaml
+++ b/.github/workflows/pixi-sphinx-linkcheck.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false  # Required to avoid exposing secrets to the linkcheck process in forked PRs
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -3,6 +3,8 @@
 
 name: pytest-with-coverage
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
 
       - name: Get current date for downloads cache key
         id: date

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -23,6 +23,7 @@ on:
 
 jobs:
   pytest-with-coverage:
+    name: pytest with coverage in ${{ inputs.conda-env-name }} environment
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false  # Required to avoid exposing secrets to pytest run in forked PRs
 
       - name: Get current date for downloads cache key
         id: date

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -23,6 +23,7 @@ on:
 
 jobs:
   sphinx-linkcheck:
+    name: Sphinx linkcheck in ${{ inputs.conda-env-name }} environment
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
 
       - name: Get current date for downloads cache key
         id: date

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -2,6 +2,8 @@
 
 name: sphinx-linkcheck
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false  # Required to avoid exposing secrets to the linkcheck process in forked PRs
 
       - name: Get current date for downloads cache key
         id: date

--- a/.github/workflows/update-pixi-lockfile.yaml
+++ b/.github/workflows/update-pixi-lockfile.yaml
@@ -2,6 +2,8 @@
 
 name: update-pixi-lockfile
 
+permissions: {}
+
 on:
   # Enable workflow to be triggered from GitHub CLI, browser, or via API
   workflow_dispatch:

--- a/.github/workflows/update-pixi-lockfile.yaml
+++ b/.github/workflows/update-pixi-lockfile.yaml
@@ -14,7 +14,6 @@ on:
 jobs:
   update-pixi-lockfile:
     name: Update pixi lockfile and create pull request
-    runs-on: ubuntu-latest
     permissions:
       contents: write  # Required to create pull request with updated lockfile
       pull-requests: write  # Required to create pull request with updated lockfile

--- a/.github/workflows/update-pixi-lockfile.yaml
+++ b/.github/workflows/update-pixi-lockfile.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   update-pixi-lockfile:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # Required to create pull request with updated lockfile
+      pull-requests: write  # Required to create pull request with updated lockfile
 
     uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-lockfile-updater.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/update-pixi-lockfile.yaml
+++ b/.github/workflows/update-pixi-lockfile.yaml
@@ -17,4 +17,4 @@ jobs:
       contents: write
       pull-requests: write
 
-    uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-lockfile-updater.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-lockfile-updater.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/update-pixi-lockfile.yaml
+++ b/.github/workflows/update-pixi-lockfile.yaml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   update-pixi-lockfile:
+    name: Update pixi lockfile and create pull request
+    runs-on: ubuntu-latest
     permissions:
       contents: write  # Required to create pull request with updated lockfile
       pull-requests: write  # Required to create pull request with updated lockfile


### PR DESCRIPTION
* locked down permissions in all workflows to prevent leakage of default permissions
* added pragma comments to tell `zizmor` to ignore unpinned uses of our own reusable workflows
* added explanatory comments to permissions items
* added pragma comments to tell `zizmor` to ignore major version pins instead of hash pins on uses of GitHub actions as a reasonable trade-off between security and convenience
* added `perist-credentials: false` to `actions/checkout` uses to potential exposure of secrets in forked PRs
* added names to anonymous workflow jobs to improve readability in GHA UI
